### PR TITLE
Update algorithm.py/extend: Fixing cost calculation

### DIFF
--- a/cws/algorithm.py
+++ b/cws/algorithm.py
@@ -84,7 +84,7 @@ class Route (object):
         :param edges: The new edges to add to the route.
         """
         self.edges.extend(edges)
-        self.cost += sum(edge.cost for edge in self.edges)
+        self.cost += sum(edge.cost for edge in edges)
 
     def append (self, edge):
         """


### PR DESCRIPTION
Fix for cost of new route, adding only cost of new edges as cost of current edges already contained. See issue #1 